### PR TITLE
Create a Heroku Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rake db:migrate

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "confbuddies@chael.codes"
   layout "mailer"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,16 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "ConfBuddies_production"
 
+  config.action_mailer.default_url_options = { host: "confbuddies.herokuapp.com" }
+  config.action_mailer.smtp_settings = {
+    port: ENV["SENDGRID_PORT"],
+    address: ENV["SENDGRID_SERVER"],
+    user_name: ENV["SENDGRID_USERNAME"],
+    password: ENV["SENDGRID_PASSWORD"],
+    domain: "chael.codes",
+    authentication: :plain,
+    ssl: true
+  }
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "confbuddies@chael.codes"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
# Description
When we deploy the application in Heroku, we need to run any database migrations. I am very bad at remembering to run these manually. Additionally, if the migration is run in the release step, the changes to the database will be deployed alongside the code changes.

# Changes
Add a heroku profile that will automatically run database migrations using `rake db:migrate`.