### PR TITLE
Format Date/Time for Events

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -2,4 +2,13 @@
 
 # Helper for Events
 module EventsHelper
+  def date_range(event)
+    start_date = event.start_at.to_date
+    if (event.end_at - event.start_at) > 1.day
+      end_date = event.end_at.to_date
+      "#{l(start_date, format: :long)} - #{l(end_date, format: :long)}"
+    else
+      "#{l(start_date, format: :long)} #{l event.start_at, format: :time}-#{l event.end_at, format: :time}"
+    end
+  end
 end

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -11,7 +11,7 @@
     <% events.each do |event| %>
       <tr>
         <td><%= link_to event, event %></td>
-        <td><%= event.description %></td>
+        <td style="max-width: 500px; min-width: 1px"><%= event.description %></td>
         <td><%= date_range(event) %></td>
         <td><%= link_to 'Edit', edit_event_path(event) %></td>
         <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -3,9 +3,7 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th>Start at</th>
-      <th>End at</th>
-      <th colspan="2"></th>
+      <th colspan="3"></th>
     </tr>
   </thead>
 
@@ -14,8 +12,7 @@
       <tr>
         <td><%= link_to event, event %></td>
         <td><%= event.description %></td>
-        <td><%= event.start_at %></td>
-        <td><%= event.end_at %></td>
+        <td><%= date_range(event) %></td>
         <td><%= link_to 'Edit', edit_event_path(event) %></td>
         <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,21 +1,7 @@
-<p>
-  <strong>Name:</strong>
-  <%= @event.name %>
-</p>
-
-<p>
-  <strong>Description:</strong>
+<h1><%= @event.name %></h1>
+<subtitle><%= date_range(@event) %></subtitle>
+<p role="doc-subtitle">
   <%= @event.description %>
-</p>
-
-<p>
-  <strong>Start at:</strong>
-  <%= @event.start_at %>
-</p>
-
-<p>
-  <strong>End at:</strong>
-  <%= @event.end_at %>
 </p>
 
 <%= link_to 'Edit', edit_event_path(@event) %> |

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -6,17 +6,16 @@
       <th>Name</th>
       <th>Handle</th>
       <th>Bio</th>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @profiles.each do |profile| %>
       <tr>
-        <td><%= profile.name %></td>
+        <td><%= link_to profile, profile %></td>
         <td><%= profile.handle %></td>
         <td><%= profile.bio %></td>
-        <td><%= link_to 'Show', profile %></td>
         <td><%= link_to 'Edit', edit_profile_path(profile) %></td>
         <td><%= link_to 'Destroy', profile, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  time:
+    formats:
+      time: "%H:%M"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -6,5 +6,11 @@ FactoryBot.define do
     description { "[RubyConf 2020](https://rubyconf.org/) will be held in Denver." }
     start_at { "2021-11-08 00:00:00" }
     end_at { "2021-11-10 00:00:00" }
+
+    trait :one_day do
+      name { "HexDevs Open-Source" }
+      start_at { "2021-08-05 21:00:00" }
+      end_at { "2021-08-05 23:59:00" }
+    end
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -2,16 +2,21 @@
 
 require "rails_helper"
 
-# Specs in this file have access to a helper object that includes
-# the EventsHelper. For example:
-#
-# describe EventsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe EventsHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#date_range" do
+    subject { date_range(event) }
+
+    let(:event) { create :event }
+
+    it { is_expected.to eq "November 08, 2021 - November 10, 2021" }
+
+    context "when 1 day event" do
+      let(:event) do
+        create :event, name: "HexDevs Open-Source",
+                       start_at: "2021-08-05 21:00:00", end_at: "2021-08-05 23:59:00"
+      end
+
+      it { is_expected.to eq "August 05, 2021 21:00-23:59" }
+    end
+  end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -11,10 +11,7 @@ RSpec.describe EventsHelper, type: :helper do
     it { is_expected.to eq "November 08, 2021 - November 10, 2021" }
 
     context "when 1 day event" do
-      let(:event) do
-        create :event, name: "HexDevs Open-Source",
-                       start_at: "2021-08-05 21:00:00", end_at: "2021-08-05 23:59:00"
-      end
+      let(:event) { create :event, :one_day }
 
       it { is_expected.to eq "August 05, 2021 21:00-23:59" }
     end


### PR DESCRIPTION
# Description
Dates used to look messy on the profile and events/index page. They would show dates and times for all dates. Also, took this as an opportunity to clarify the Event Show page, and shorten description on event index.

Before | After
--- | ---
![multi-day before](https://user-images.githubusercontent.com/8124558/127781730-1a44ebc1-7266-4338-9a6c-b74b93ce2a78.png) |  ![multi-day after](https://user-images.githubusercontent.com/8124558/127781326-d178c375-d37b-4bdb-8a13-89fad59a13df.png)
![1-day before](https://user-images.githubusercontent.com/8124558/127781741-368a5906-05c2-4940-8561-175328a39e58.png) | ![1-day after](https://user-images.githubusercontent.com/8124558/127781590-5185f4ca-706c-402f-acc2-926438c64348.png)
![image](https://user-images.githubusercontent.com/8124558/127781852-fd184974-d2f8-4150-81bd-8b3566e5e51d.png) | ![image](https://user-images.githubusercontent.com/8124558/127781894-df9f052e-2353-4269-a5d9-e7185425e10e.png)



# Changes
- New helper for events that displays a clean range for date ranges
- More than 1-day events do not show time
- Less than 1-day events do not show the date twice
- Events Index page only shows 500px of description
- Refactored Show page