### PR TITLE
Attend Events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ RSpec/ExampleLength:
 RSpec/HookArgument:
   EnforcedStyle: each
 
+RSpec/LetSetup:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -13,4 +13,8 @@ class Profile < ApplicationRecord
   def to_s
     name
   end
+
+  def attending?(event)
+    event_attendees.where(event: event).any?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :confirmable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_one :profile, dependent: :destroy
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,18 @@
 <h1><%= @event.name %></h1>
-<subtitle><%= date_range(@event) %></subtitle>
-<p role="doc-subtitle">
+<p role="doc-subtitle"><%= date_range(@event) %></p>
+<% if current_user&.profile&.attending? @event %>
+  <p>Attending</p>
+<% elsif current_user %>
+  <%= button_to "Attend",
+    event_attendees_path(
+      event_attendee: {
+                        profile_id: current_user.profile,
+                        event_id: @event.id
+                      }
+    ),
+    action: "create" %>
+<% end %>
+<p>
   <%= @event.description %>
 </p>
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -3,5 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Profile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:profile) { create :profile }
+
+  describe "#attending?" do
+    subject { profile.attending? event }
+
+    let(:event) { create :event }
+
+    it { is_expected.to be_falsey }
+
+    context "when profile is attending" do
+      let!(:event_attendee) { create :event_attendee, profile: profile, event: event }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
# Description

We have Events and we have Profiles, and we track which Profile are Attending Events. Now let's make it easier to attend Events, directly from the Event page.

# Changes
Add a button on the event page to create an event attendee. or show that they are attending the event.
