### PR TITLE
Set up Admin Permissions for Profiles and Events

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,44 @@
 
 # Any needed Application UI functions
 module ApplicationHelper
+  # Display buttons for the show page
+  def buttons_for_show(resource)
+    buttons = []
+    buttons << edit_link(resource)
+    buttons << delete_link(resource)
+    buttons << index_link(resource)
+    safe_join(buttons.compact_blank, "|")
+  end
+
+  # Display buttons for the show page
+  def buttons_for_index(resource)
+    buttons = []
+    buttons << edit_link(resource)
+    buttons << delete_link(resource)
+    buttons.map do |button|
+      tag.td { button }
+    end
+    safe_join(buttons)
+  end
+
+  # Delete Link if the user has permission
+  def delete_link(resource)
+    return unless policy(resource).destroy?
+    link_to("Delete",
+            url_for(resource),
+            method: :delete,
+            data: { confirm: "Are you sure?" })
+  end
+
+  # Edit Link if the user has permission
+  def edit_link(resource)
+    return unless policy(resource).edit?
+    link_to("Edit", url_for([:edit, resource]))
+  end
+
+  # Index Link if the user has permission
+  def index_link(resource)
+    return unless policy(resource).index?
+    link_to("All #{resource.model_name.human.pluralize.titleize}", url_for(resource.class))
+  end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -2,24 +2,29 @@
 
 # Rules governing permissions for Events
 class EventPolicy < ApplicationPolicy
+  # Everyone can view Event details
   def show?
     true
   end
 
+  # Everyone can view Event details
   def index?
     true
   end
 
+  # Logged in users can create Events
   def create?
     user.present?
   end
 
+  # Only Admins can update Events
   def update?
-    user.present?
+    user&.admin?
   end
 
+  # Only Admins can destroy Events
   def destroy?
-    user.present?
+    user&.admin?
   end
 
   # Rules governing a list of Events

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -26,7 +26,8 @@ class ProfilePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user && user.id == profile.user_id
+    return false unless user
+    user.admin? || user.id == profile.user_id
   end
 
   # Permissions and access for a collection of Users

--- a/app/views/event_attendees/show.html.erb
+++ b/app/views/event_attendees/show.html.erb
@@ -10,5 +10,4 @@
   <%= link_to @event_attendee.event, @event_attendee.event %>
 </p>
 
-<%= link_to 'Edit', edit_event_attendee_path(@event_attendee) %> |
-<%= link_to 'Back', event_attendees_path %>
+<%= buttons_for_show(@event_attendee) %>

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <th>Name</th>
       <th>Description</th>
-      <th colspan="3"></th>
+      <th colspan="2"></th>
     </tr>
   </thead>
 
@@ -13,8 +13,7 @@
         <td><%= link_to event, event %></td>
         <td style="max-width: 500px; min-width: 1px"><%= event.description %></td>
         <td><%= date_range(event) %></td>
-        <td><%= link_to 'Edit', edit_event_path(event) %></td>
-        <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <%= buttons_for_index(event) %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,5 +16,4 @@
   <%= @event.description %>
 </p>
 
-<%= link_to 'Edit', edit_event_path(@event) %> |
-<%= link_to 'Back', events_path %>
+<%= buttons_for_show(@event) %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -16,8 +16,7 @@
         <td><%= link_to profile, profile %></td>
         <td><%= profile.handle %></td>
         <td><%= profile.bio %></td>
-        <td><%= link_to 'Edit', edit_profile_path(profile) %></td>
-        <td><%= link_to 'Destroy', profile, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <%= buttons_for_index(profile) %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -15,5 +15,4 @@
 
 <%= render 'events/list', events: @events %>
 
-<%= link_to 'Edit', edit_profile_path(@profile) %> |
-<%= link_to 'Back', profiles_path %>
+<%= buttons_for_show(@profile) %>

--- a/db/migrate/20210803200434_add_admin_to_users.rb
+++ b/db/migrate/20210803200434_add_admin_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add an admin column to users table
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :bool
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_25_175219) do
+ActiveRecord::Schema.define(version: 2021_08_03_200434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_07_25_175219) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.boolean "admin"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :unconfirmed do
       confirmed_at { nil }
     end
+
+    trait :admin do
+      admin { true }
+    end
   end
 end

--- a/spec/features/events/index_spec.rb
+++ b/spec/features/events/index_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Events" do
+  let!(:event) { create(:event) }
+  let(:user) { nil }
+
+  before(:each) do
+    sign_in user if user
+    visit "/events/".dup
+  end
+
+  it "shows the event" do
+    expect(page).to have_link "RubyConf", href: event_path(event)
+    expect(page).not_to have_link "Edit", href: edit_event_path(event)
+    expect(page).not_to have_link "Delete", href: event_path(event)
+  end
+
+  context "when user logged in" do
+    let(:user) { create :user }
+
+    it "shows the event" do
+      expect(page).to have_link "RubyConf", href: event_path(event)
+      expect(page).not_to have_link "Edit", href: edit_event_path(event)
+      expect(page).not_to have_link "Delete", href: event_path(event)
+    end
+
+    context "when user is admin" do
+      let(:user) { create :user, :admin }
+
+      it "allows user to edit and destroy event" do
+        expect(page).to have_link "RubyConf", href: event_path(event)
+        expect(page).to have_link "Edit", href: edit_event_path(event)
+        expect(page).to have_link "Delete", href: event_path(event)
+      end
+    end
+  end
+end

--- a/spec/features/events/show_spec.rb
+++ b/spec/features/events/show_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Events" do
+  let(:event) { create(:event) }
+  let(:user) { nil }
+
+  before(:each) do
+    sign_in user if user
+    visit "/events/#{event.id}".dup
+  end
+
+  it "shows the event" do
+    expect(page).to have_content "RubyConf"
+    expect(page).not_to have_link "Edit", href: edit_event_path(event)
+    expect(page).not_to have_link "Delete", href: event_path(event)
+    expect(page).to have_link "All Events", href: events_path
+  end
+
+  context "when user logged in" do
+    let(:user) { create :user }
+
+    it "shows the event" do
+      expect(page).to have_content "RubyConf"
+      expect(page).not_to have_link "Edit", href: edit_event_path(event)
+      expect(page).not_to have_link "Delete", href: event_path(event)
+    end
+
+    context "when user is admin" do
+      let(:user) { create :user, :admin }
+
+      it "allows user to edit and destroy event" do
+        expect(page).to have_content "RubyConf"
+        expect(page).to have_link "Edit", href: edit_event_path(event)
+        expect(page).to have_link "Delete", href: event_path(event)
+      end
+    end
+  end
+end

--- a/spec/features/profiles/show_spec.rb
+++ b/spec/features/profiles/show_spec.rb
@@ -17,8 +17,28 @@ describe "Profile" do
       visit "/profiles/#{profile.id}".dup
     end
 
-    it "shows the PROFILE" do
+    it "shows the profile" do
       expect(page).to have_content "ChaelCodes"
+      expect(page).not_to have_link "Edit", href: edit_profile_path(profile)
+      expect(page).not_to have_link "Delete", href: profile_path(profile)
+    end
+
+    context "when profile belongs to the user" do
+      let(:user) { profile.user }
+
+      it "allows user to edit profile" do
+        expect(page).to have_link "Edit", href: edit_profile_path(profile)
+        expect(page).to have_link "Delete", href: profile_path(profile)
+      end
+    end
+
+    context "when user is admin" do
+      let(:user) { create :user, :admin }
+
+      it "allows user to destroy profile" do
+        expect(page).not_to have_link "Edit", href: edit_profile_path(profile)
+        expect(page).to have_link "Delete", href: profile_path(profile)
+      end
     end
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -52,7 +52,13 @@ RSpec.describe "/events", type: :request do
     context "when user is logged in" do
       let(:user) { create :user }
 
-      it "render a successful response" do
+      include_examples "unauthorized access"
+    end
+
+    context "when admin" do
+      let(:user) { create :user, :admin }
+
+      it "renders a successful response" do
         get_edit
         expect(response).to be_successful
       end
@@ -110,6 +116,12 @@ RSpec.describe "/events", type: :request do
     context "with logged in user" do
       let(:user) { create :user }
 
+      include_examples "unauthorized access"
+    end
+
+    context "with admin user" do
+      let(:user) { create :user, :admin }
+
       it "updates the requested event" do
         patch_update
         event.reload
@@ -140,8 +152,14 @@ RSpec.describe "/events", type: :request do
 
     include_examples "redirect to sign in"
 
-    context "when user is logged in" do
+    context "with logged in user" do
       let(:user) { create :user }
+
+      include_examples "unauthorized access"
+    end
+
+    context "when User is admin" do
+      let(:user) { create :user, :admin }
 
       it "destroys the requested event" do
         expect { delete_destroy }.to change(Event, :count).by(-1)

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -129,6 +129,18 @@ RSpec.describe "/profiles", type: :request do
           expect(response).to redirect_to(profile_url(profile))
         end
       end
+
+      context "with admin" do
+        let(:user) { create :user, :admin }
+
+        include_examples "unauthorized access"
+
+        it "does not update profile" do
+          patch_update
+          profile.reload
+          expect(profile.handle).to eq "ChaelCodes"
+        end
+      end
     end
 
     context "with invalid parameters" do
@@ -147,8 +159,23 @@ RSpec.describe "/profiles", type: :request do
 
     let!(:profile) { create :profile }
 
+    include_examples "unauthorized access"
+
     context "with profile's creator" do
       let(:user) { profile.user }
+
+      it "destroys the requested profile" do
+        expect { delete_destroy }.to change(Profile, :count).by(-1)
+      end
+
+      it "redirects to the profiles list" do
+        delete_destroy
+        expect(response).to redirect_to(profiles_url)
+      end
+    end
+
+    context "with an admin" do
+      let(:user) { create :user, :admin }
 
       it "destroys the requested profile" do
         expect { delete_destroy }.to change(Profile, :count).by(-1)

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "/profiles", type: :request do
 
         include_examples "unauthorized access"
 
-        it "does not update profile" do
+        it "does not update the profile" do
           patch_update
           profile.reload
           expect(profile.handle).to eq "ChaelCodes"


### PR DESCRIPTION
# Description
closes #14 
starts #12
People aren't always nice. The goal of this app is to find ConfBuddies, not make ConfEnemies. When there is conduct or content that goes against our Code of Conduct, we need admins that can step in and remove that content.

Also, let's not let people see buttons they can't click, am I right?

# Description of Changes
- Create Admins to manage Events and Profiles
- Allow Admin to Destroy, but not Edit Profiles
- Do not show edit/destroy buttons to user who can't use them

Page | Before | After
--- | --- | --- 
