### PR TITLE
#32 - Scope Event Index to events that have not happened yet

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
 
   # GET /events or /events.json
   def index
-    @events = Event.all
+    @events = Event.ongoing_or_upcoming
   end
 
   # GET /events/1 or /events/1.json

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,8 @@ class Event < ApplicationRecord
 
   validates :start_at, :end_at, presence: true
 
+  scope :ongoing_or_upcoming, -> { where("end_at >= ?", Time.zone.now) }
+
   def to_s
     name
   end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -12,5 +12,12 @@ FactoryBot.define do
       start_at { "2021-08-05 21:00:00" }
       end_at { "2021-08-05 23:59:00" }
     end
+
+    trait :past_event do
+      name { "PastConf" }
+      description { "The conference you always miss by a few days." }
+      start_at { 3.days.ago }
+      end_at { 1.day.ago }
+    end
   end
 end

--- a/spec/features/events/index_spec.rb
+++ b/spec/features/events/index_spec.rb
@@ -17,6 +17,11 @@ describe "Events" do
     expect(page).not_to have_button "Delete"
   end
 
+  it "only shows future events" do
+    past_event = create(:event, :past_event)
+    expect(page).not_to have_link past_event.name, href: event_path(past_event)
+  end
+
   context "when user logged in" do
     let(:user) { create :user }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,5 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:event) { create :event }
+
+  it { expect(event).to be_valid }
+
+  describe "#ongoing_or_upcoming" do
+    subject { described_class.ongoing_or_upcoming }
+
+    let!(:past_event) { create :event, :past_event }
+    let!(:upcoming_event) { create :event, start_at: 3.days.from_now, end_at: 5.days.from_now }
+    let!(:ongoing_event) { create :event, start_at: 3.days.ago, end_at: 1.day.from_now }
+
+    it { is_expected.to include(upcoming_event) }
+    it { is_expected.to include(ongoing_event) }
+    it { is_expected.not_to include(past_event) }
+  end
 end


### PR DESCRIPTION
- Added a scope to the Event model to get ongoing or upcoming Events.
- Added spec for testing that only future and ongoing events are selected, while past events are not.
- Updated events controller to select only ongoing or upcoming events.