### PR TITLE
added few helper scripts

### DIFF
--- a/scripts/db
+++ b/scripts/db
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+compose="docker compose"
+
+if ! docker compose > /dev/null; then
+  if ! command -v docker-compose > /dev/null; then
+    echo "docker compose is not installed"
+    exit 1
+  fi
+  compose="docker-compose"
+fi
+
+setup() {
+  $compose run --rm web bundle exec rake db:setup
+}
+
+migrate() {
+  $compose run --rm web bundle exec rake db:migrate
+}
+
+reset() {
+  if [ "$(docker ps -q -f name=conf-buddies_web)" ]; then
+    $compose stop web
+    $compose run web bundle exec rake db:reset
+    $compose start web
+  else
+    $compose run web bundle exec rake db:reset
+  fi
+}
+
+case $1 in
+  setup)
+    setup
+    ;;
+  migrate)
+    migrate
+    ;;
+  reset)
+    reset
+    ;;
+  *)
+    echo "unknown db command: $1"
+    echo "available commands: migrate, reset and setup"
+    exit 1
+esac

--- a/scripts/psql
+++ b/scripts/psql
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+compose="docker compose"
+
+if ! docker compose > /dev/null; then
+  if ! command -v docker-compose > /dev/null; then
+    echo "docker compose is not installed"
+    exit 1
+  fi
+  compose="docker-compose"
+fi
+
+$compose exec db psql -U postgres ConfBuddies_development

--- a/scripts/rails-c
+++ b/scripts/rails-c
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+compose="docker compose"
+
+if ! docker compose > /dev/null; then
+  if ! command -v docker-compose > /dev/null; then
+    echo "docker compose is not installed"
+    exit 1
+  fi
+  compose="docker-compose"
+fi
+
+$compose run --rm web bin/rails c

--- a/scripts/rspec
+++ b/scripts/rspec
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+compose="docker compose"
+
+if ! docker compose > /dev/null; then
+  if ! command -v docker-compose > /dev/null; then
+    echo "docker compose is not installed"
+    exit 1
+  fi
+  compose="docker-compose"
+fi
+
+$compose run --rm web bundle exec rspec

--- a/scripts/rubocop
+++ b/scripts/rubocop
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+compose="docker compose"
+
+if ! docker compose > /dev/null; then
+  if ! command -v docker-compose > /dev/null; then
+    echo "docker compose is not installed"
+    exit 1
+  fi
+  compose="docker-compose"
+fi
+
+$compose run --rm web bundle exec rubocop


### PR DESCRIPTION
This PR adds a few bash scripts that abstracts away a lot of the long `docker compose` commands, e.g.:

Now, if you want to reset the database, you'll have to write up to three different `docker compose` commands
+ `docker compose stop web`
+ `docker compose run web bundle exec rake db:reset`
+ `docker compose start web`

but with the new `db` script you just have to run `./db reset`.

The scripts also checks whether `docker compose` is available, otherwise `docker-compose` will be used.

#### New scripts
+ `psql` => `docker compose exec db psql -U postgres ConfBuddies_development`
+ `rails-c` => `docker compose run --rm web bin/rails c`
+ `rspec` => `docker compose run --rm web bundle exec rspec`
+ `rubocop` => `docker compose run --rm web bundle exec rubocop`
+ `db` => This script comes with three commands; `setup`, `migrate` and `reset`. (`./db <command>`)
