### PR TITLE
Correct docker-compose.yml to work with docker compose v2 in WSL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - "./:/app/"
+      - "./:/app"
   db:
     image: postgres:13
     env_file:


### PR DESCRIPTION
## Description of Feature or Issue

I was watching your Sunday stream this morning and noticed [the issue you had with WSL](https://github.com/ChaelCodes/ConfBuddies/blob/main/CONTRIBUTING.md#trouble-shooting), and knew how to prevent this. 

It is a result of the trailing slash on the docker path in the volumes defined in the `docker-compose.yml` file. Removing the trailing slash prevents this from happening.
