### PR TITLE
Form error field class

### DIFF
--- a/config/initializers/customize_error.rb
+++ b/config/initializers/customize_error.rb
@@ -1,0 +1,12 @@
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  class_attr_index = html_tag.index 'class="'
+  label = html_tag.index 'label'
+
+  if label
+    html_tag
+  elsif class_attr_index
+    html_tag.insert class_attr_index + 7, 'is-danger '
+  else
+    "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe
+  end
+end

--- a/config/initializers/customize_error.rb
+++ b/config/initializers/customize_error.rb
@@ -1,12 +1,18 @@
-ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+# frozen_string_literal: true
+
+# Customize the field errors output by ActionView to include the 'is-danger' class.
+ActionView::Base.field_error_proc = proc do |html_tag, _instance|
   class_attr_index = html_tag.index 'class="'
-  label = html_tag.index 'label'
+  label = html_tag.index "label"
 
   if label
     html_tag
   elsif class_attr_index
-    html_tag.insert class_attr_index + 7, 'is-danger '
+    html_tag.insert class_attr_index + 7, "is-danger "
   else
+    # rubocop:disable Rails/OutputSafety
+    # It is ok to mark this as safe because there is no user-input.
     "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 end

--- a/spec/requests/field_error_spec.rb
+++ b/spec/requests/field_error_spec.rb
@@ -14,13 +14,16 @@ RSpec.describe "/profiles", type: :request do
   end
 
   describe "POST /create" do
-    let(:attributes) { {handle: ""} } # Blank to kick out an error.
     subject(:post_create) { post profiles_url, params: { profile: attributes } }
 
+    let(:attributes) { { handle: "" } } # Blank to kick out an error.
+
     context "with invalid parameters" do
+      before(:each) do
+        post_create
+      end
 
       it "includes the error class" do
-        expect { post_create }.not_to change(Profile, :count)
         expect(response.body).to match(/input class="(.*)is-danger(.*)"/)
       end
     end

--- a/spec/requests/field_error_spec.rb
+++ b/spec/requests/field_error_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# #109 - Arbitrarily choose profiles as a base to test against.
+RSpec.describe "/profiles", type: :request do
+  let(:profile) { create :profile }
+
+  # Test all routes as an authenticated user
+  let(:user) { create :user }
+
+  before(:each) do
+    sign_in user
+  end
+
+  describe "POST /create" do
+    let(:attributes) { {handle: ""} } # Blank to kick out an error.
+    subject(:post_create) { post profiles_url, params: { profile: attributes } }
+
+    context "with invalid parameters" do
+
+      it "includes the error class" do
+        expect { post_create }.not_to change(Profile, :count)
+        expect(response.body).to match(/input class="(.*)is-danger(.*)"/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of Feature or Issue
closes #107

Added an initializer to customize the CSS class added by ActiolnView to a field when in an error state.  The class being added is 'is-danger'.

## Checklist
- [ x] Added/changed specs for the changes made
- [ x] Is the linting build successful?
- [ x] Is the test build successful?

## User-Facing Changes

Should see a error highlight when a field is not validated.  At the moment, that highlight is red per pre-existing styles.
