### PR TITLE
Protect Profiles on the Index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,7 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Exclude:
     - "spec/features/**/*"
+    - "spec/requests/**/*"
 
 RSpec/NestedGroups:
   Enabled: false

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -10,10 +10,10 @@ class FriendshipsController < ApplicationController
   def index
     return unless current_user.profile
     @profile = current_user.profile
-    @friendships = Friendship.where(friend_id: @profile.id,
-                                    status: :accepted).or(Friendship.where(
-                                                            buddy_id: @profile.id, status: :accepted
-                                                          ))
+    @friendships = Friendship.where(friend_id: @profile.id, status: :accepted)
+                             .or(Friendship.where(
+                                   buddy_id: @profile.id, status: :accepted
+                                 ))
   end
 
   # GET /friendships/1 or /friendships/1.json

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,7 +8,7 @@ class ProfilesController < ApplicationController
 
   # GET /profiles or /profiles.json
   def index
-    @profiles = Profile.all
+    @profiles = policy_scope(Profile)
   end
 
   # GET /profiles/1 or /profiles/1.json
@@ -70,8 +70,8 @@ class ProfilesController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_profile
-    @profile = policy_scope(Profile).find_by("LOWER(handle) = ?", params[:id]&.downcase)
-    @profile ||= policy_scope(Profile).find(params[:id])
+    @profile = Profile.find_by("LOWER(handle) = ?", params[:id]&.downcase)
+    @profile ||= Profile.find(params[:id])
     authorize @profile
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
       confirmed_at { nil }
       after(:create) do |user|
         # Overwrite confirmation_sent_at
-        user.update(confirmation_sent_at: 2.days.ago)
+        user.update(confirmation_sent_at: 4.days.ago)
       end
     end
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -29,16 +29,8 @@ describe "Users" do
     end
   end
 
-  context "when overdue_unconfirmed user logged in does not match" do
+  context "when user overdue for confirmation" do
     let(:user) { create(:user, :overdue_unconfirmed) }
-
-    it "permission to edit denied" do
-      expect(page).to have_content "You are not authorized to perform this action."
-    end
-  end
-
-  context "when user unconfirmed" do
-    let(:user) { create(:user, :unconfirmed) }
 
     it "prompts the user to confirm email" do
       expect(page).to have_content "You have to confirm your email address before continuing."

--- a/spec/requests/event_attendees_spec.rb
+++ b/spec/requests/event_attendees_spec.rb
@@ -121,42 +121,26 @@ RSpec.describe "/event_attendees", type: :request do
           expect(response).to redirect_to(event_attendee_url(EventAttendee.last))
         end
       end
-    end
 
-    context "with valid parameters and overdue_unconfirmed user" do
-      let(:user) { create :user, :overdue_unconfirmed }
-      let(:profile) { create :profile, user: user }
+      context "when user matches profile but is overdue on email confirmation" do
+        let(:user) { create :user, :overdue_unconfirmed }
+        let(:profile) { create :profile, user: user }
 
-      let(:attributes) do
-        {
-          profile_id: profile.id,
-          event_id: create(:event).id
-        }
+        it_behaves_like "confirm your email"
       end
 
-      it "creates a new EventAttendee" do
-        expect { post_create }.to change(EventAttendee, :count).by(1)
-      end
+      context "when user matches profile and is unconfirmed" do
+        let(:user) { create :user, :unconfirmed_with_trial }
+        let(:profile) { create :profile, user: user }
 
-      it "redirects to the created event_attendee" do
-        post_create
-        expect(response).to redirect_to(event_attendee_url(EventAttendee.last))
-      end
-    end
+        it "creates a new EventAttendee" do
+          expect { post_create }.to change(EventAttendee, :count).by(1)
+        end
 
-    context "with valid parameters and unconfirmed user" do
-      let(:user) { create :user, :unconfirmed }
-      let(:profile) { create :profile, user: user }
-
-      let(:attributes) do
-        {
-          profile_id: profile.id,
-          event_id: create(:event).id
-        }
-      end
-
-      it "creates a new EventAttendee" do
-        expect { post_create }.to change(EventAttendee, :count).by(0)
+        it "redirects to the created event_attendee" do
+          post_create
+          expect(response).to redirect_to(event_attendee_url(EventAttendee.last))
+        end
       end
     end
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -13,15 +13,27 @@ RSpec.describe "/profiles", type: :request do
     sign_in user if user
   end
 
+  # rubocop:disable RSpec/MultipleExpectations
   describe "GET /index" do
     subject(:get_index) { get profiles_url }
 
-    let!(:profile) { create :profile }
+    let!(:public_profile) { create :profile, visibility: :everyone }
+    let!(:authenticated_profile) { create :profile, visibility: :authenticated }
+    let!(:not_friends_profile) { create :profile, visibility: :friends }
+    let!(:friends_profile) { create :profile, visibility: :friends }
+    let!(:private_profile) { create :profile, visibility: :myself }
+    let!(:my_profile) { create :profile, user: user }
+    let!(:friendship) { create :friendship, buddy: my_profile, friend: friends_profile, status: :accepted }
 
     context "when the profile belongs to a confirmed user" do
       it "renders a successful response" do
         get_index
-        expect(response.body).to include(profile.name)
+        expect(response.body).to include(public_profile.handle)
+        expect(response.body).to include(authenticated_profile.handle)
+        expect(response.body).not_to include(not_friends_profile.handle)
+        expect(response.body).not_to include(private_profile.handle)
+        expect(response.body).to include(friends_profile.handle)
+        expect(response.body).to include(my_profile.handle)
       end
     end
 
@@ -30,19 +42,22 @@ RSpec.describe "/profiles", type: :request do
 
       it "shows only public profiles" do
         get_index
-        expect(response.body).to include(profile.name)
+        expect(response.body).to include(public_profile.handle)
+        expect(response.body).not_to include(authenticated_profile.handle)
+        expect(response.body).not_to include(not_friends_profile.handle)
+        expect(response.body).not_to include(private_profile.handle)
+        expect(response.body).to include(friends_profile.handle)
+        expect(response.body).to include(my_profile.handle)
       end
     end
 
     context "when the profile belongs to a overdue unconfirmed user" do
       let(:user) { create :user, :overdue_unconfirmed }
 
-      it "renders a successful response" do
-        get_index
-        expect(response.body).not_to include(profile.name)
-      end
+      it_behaves_like "confirm your email"
     end
   end
+  # rubocop:enable RSpec/MultipleExpectations
 
   describe "GET /show" do
     subject(:get_show) { get profile_url(profile), headers: headers }

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -25,12 +25,21 @@ RSpec.describe "/profiles", type: :request do
       end
     end
 
-    context "when the profile belongs to a confirmed overdue_unconfirmed user" do
+    context "when the profile belongs to an unconfirmed user in the grace period" do
+      let(:user) { create :user, :unconfirmed_with_trial }
+
+      it "shows only public profiles" do
+        get_index
+        expect(response.body).to include(profile.name)
+      end
+    end
+
+    context "when the profile belongs to a overdue unconfirmed user" do
       let(:user) { create :user, :overdue_unconfirmed }
 
       it "renders a successful response" do
         get_index
-        expect(response.body).to include(profile.name)
+        expect(response.body).not_to include(profile.name)
       end
     end
   end
@@ -204,24 +213,24 @@ RSpec.describe "/profiles", type: :request do
         post_create
         expect(response).to redirect_to(profile_url(Profile.last))
       end
-    end
 
-    context "with valid parameters and overdue_unconfirmed user" do
-      let(:attributes) do
-        {
-          handle: "ChaelCodes"
-        }
+      context "with uncofirmed user in trial period" do
+        let(:user) { create :user, :unconfirmed_with_trial }
+
+        it "creates a new Profile" do
+          expect { post_create }.to change(Profile, :count).by(1)
+        end
+
+        it "redirects to the created profile" do
+          post_create
+          expect(response).to redirect_to(profile_url(Profile.last))
+        end
       end
 
-      let(:user) { create :user, :overdue_unconfirmed }
+      context "with overdue_unconfirmed user" do
+        let(:user) { create :user, :overdue_unconfirmed }
 
-      it "creates a new Profile" do
-        expect { post_create }.to change(Profile, :count).by(1)
-      end
-
-      it "redirects to the created profile" do
-        post_create
-        expect(response).to redirect_to(profile_url(Profile.last))
+        it_behaves_like "confirm your email"
       end
     end
 

--- a/spec/support/user_access.rb
+++ b/spec/support/user_access.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Only works in feature specs
 RSpec.shared_examples "unauthenticated user does not have access" do
   before(:each) do
     sign_in user if user
@@ -23,10 +24,29 @@ RSpec.shared_examples "unauthenticated user does not have access" do
   end
 end
 
+# Examples for Request specs
+
 RSpec.shared_examples "redirect to sign in" do
   it "redirect to sign in" do
     subject
     expect(response).to redirect_to new_user_session_path
+  end
+
+  it "tells the user to sign in" do
+    subject
+    expect(flash[:alert]).to eq "You need to sign in or sign up before continuing."
+  end
+end
+
+RSpec.shared_examples "confirm your email" do
+  it "redirect to sign in" do
+    subject
+    expect(response).to redirect_to new_user_session_path
+  end
+
+  it "tells the user to confirm their email" do
+    subject
+    expect(flash[:alert]).to eq "You have to confirm your email address before continuing."
   end
 end
 


### PR DESCRIPTION
## Description of Feature or Issue
closes # No issue >_>

Previously, we protected the profile from unauthorized access on the show page, but it was still visible on the index. Users would click on a profile, and it would flash a banner saying "You are not authorized to perform this action."
![image of error banner](https://user-images.githubusercontent.com/8124558/139600254-466f50f0-0e77-4acf-93bf-536aa20d07a6.png)
Now, we hide those profiles from the Index page entirely.

Admins still see all profiles.

- Updates to unauthenticated_overdue profile factory
- Random Spacing update to friendships controller

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?

## User-Facing Changes
Banner into profiles that are not shown.
