### PR TITLE
Rails 7 Updates

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
   has_many :attendees, through: :event_attendees, source: :profile
 
   validates :start_at, :end_at, presence: true
+  validates_comparison_of :end_at, greater_than: :start_at
 
   scope :ongoing_or_upcoming, -> { where("end_at >= ?", Time.zone.now) }
 

--- a/app/views/event_attendees/_list.html.erb
+++ b/app/views/event_attendees/_list.html.erb
@@ -2,7 +2,7 @@
   <h4><%= t(".buddies_attending", count: event_attendees.count) %></h4>
   <ul>
     <% event_attendees.each do |event_attendee| %>
-      <li><%= link_to event_attendee.profile, event_attendee.profile %></li>
+      <li><%= link_to event_attendee.profile %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/event_attendees/show.html.erb
+++ b/app/views/event_attendees/show.html.erb
@@ -1,12 +1,12 @@
 <div class="container">
   <p>
     <strong>Profile:</strong>
-    <%= link_to @event_attendee.profile, @event_attendee.profile %>
+    <%= link_to @event_attendee.profile %>
   </p>
 
   <p>
     <strong>Event:</strong>
-    <%= link_to @event_attendee.event, @event_attendee.event %>
+    <%= link_to @event_attendee.event %>
   </p>
 
   <%= buttons(@event_attendee) %>

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -10,7 +10,7 @@
   <tbody>
     <% events.each do |event| %>
       <tr>
-        <td><%= link_to event, event %></td>
+        <td><%= link_to event %></td>
         <td class="is-hidden-mobile"><%= kramdown_pure_text(event.description) %></td>
         <td><%= date_range(event) %></td>
         <td><%= buttons(event) %></td>

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -6,7 +6,7 @@
       <table class="table friend-requests">
         <% @profile.friend_requests.each do |friendship| %>
           <tr>
-            <td><%= link_to friendship.buddy, friendship.buddy %></td>
+            <td><%= link_to friendship.buddy %></td>
             <td><%= be_my_buddy_button(friendship) %></td>
             <td><%= destroy_friendship_button(friendship) %></td>
             <td><%= block_button(friendship) %></td>

--- a/app/views/friendships/show.html.erb
+++ b/app/views/friendships/show.html.erb
@@ -2,12 +2,12 @@
   <div class="mb-3">
     <p>
       <strong>Friend:</strong>
-      <%= link_to @friendship.friend, @friendship.friend %>
+      <%= link_to @friendship.friend %>
     </p>
 
     <p>
       <strong>Buddy:</strong>
-      <%= link_to @friendship.buddy, @friendship.buddy %>
+      <%= link_to @friendship.buddy %>
     </p>
 
     <p>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -14,7 +14,7 @@
     <tbody>
       <% @profiles.each do |profile| %>
         <tr>
-          <td><%= link_to profile, profile %></td>
+          <td><%= link_to profile %></td>
           <td><%= profile.handle %></td>
           <td class="is-hidden-mobile"><%= profile.bio %></td>
           <td><%= buttons(profile) %></td>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,3 +98,5 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end
+
+Rack::MiniProfiler.config.start_hidden = true

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe Event, type: :model do
 
   it { expect(event).to be_valid }
 
+  describe "start_at must be before end_at" do
+    context "when start_at is after end_at" do
+      let(:event) { build :event, start_at: 1.day.from_now, end_at: Time.zone.now }
+
+      it { expect(event).not_to be_valid }
+    end
+
+    context "when start_at is before end_at" do
+      let(:event) { build :event, start_at: 1.hour.ago, end_at: Time.zone.now }
+
+      it { expect(event).to be_valid }
+    end
+  end
+
   describe "#ongoing_or_upcoming" do
     subject { described_class.ongoing_or_upcoming }
 


### PR DESCRIPTION
## Description of Feature or Issue
Rails 7 introduced a few new changes that opened the opportunity to refactor and improve things in ConfBuddies!

- [ComparisonValidator](https://github.com/rails/rails/pull/40095) makes it easier to compare two dates and see if one is before the other. We're going to check the `start_at` and `end_at` on events from now on.
- MiniProfiler is back with a vengeance! If you want to see their performance profiler in the corner of the page, it can be turned on in config/environments/development.rb. By default, it will be off.
- We can shorten multiple `link_to` statements thank to this [new change](https://github.com/rails/rails/pull/42234).

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
No user-facing changes!
