### PR TITLE
Add the ability to use a gravatar for the profile image

### DIFF
--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -2,4 +2,8 @@
 
 # Helper methods for managing Profiles
 module ProfilesHelper
+  def profile_picture(email)
+    "https://gravatar.com/avatar/#{Digest::SHA2.hexdigest(email.downcase.strip)}" \
+      "?s=80&d=retro&r=pg"
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -18,6 +18,8 @@ class Profile < ApplicationRecord
   # Relationships
   belongs_to :user
 
+  delegate :email, to: :user
+
   has_many :event_attendees, dependent: :destroy
   has_many :events, through: :event_attendees
   # Friendship has a buddy_id and a friend_id (These are both profiles)

--- a/app/views/profiles/_profile.json.jbuilder
+++ b/app/views/profiles/_profile.json.jbuilder
@@ -1,2 +1,3 @@
 json.extract! profile, :id, :name, :handle, :bio, :created_at, :updated_at
 json.url profile_url(profile, format: :json)
+json.profile_picture_url profile_picture(profile.email)

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,18 +1,33 @@
-<div class="container">
-  <div class="block">
-    <h1 class="title"><%= @profile.name %></h1>
-    <h2 class="subtitle"><%= "@#{@profile.handle}" %></h2>
-    <%= friendship_button(@profile) %>
-  </div>
-  <div class="block">
-    <p><%= @profile.bio %></p>
-  </div>
-  <% if @profile.events.present? %>
-    <div class="block">
-      <%= render 'events/list', events: @events %>
+<div class="section">
+  <div class="container">
+    <div class="media is-flex-wrap-wrap mb-3" style="row-gap:1em">
+      <figure class="media-left image">
+        <img src="<%= profile_picture(@profile.email) %>" alt="Profile pic">
+      </figure>
+      <div class="media-content">
+        <p class="has-text-weight-bold is-size-4"><%= @profile.name %></p>
+        <p class="has-text-weight-semi-bold is-size-6"><%= "@#{@profile.handle}" %></p>
+      </div>
+      <div class="media-right">
+        <%= friendship_button(@profile) %>
+      </div>
     </div>
-  <% end %>
-  <div>
+    <div class="block">
+      <p><%= @profile.bio %></p>
+    </div>
+  </div>
+</div>
+<% if @profile.events.present? %>
+  <div class="section">
+    <div class="container">
+      <div class="block">
+        <%= render 'events/list', events: @events %>
+      </div>
+    </div>
+  </div>
+<% end %>
+<div class="section">
+  <div class="container">
     <%= buttons(@profile, include_nav: true) %>
   </div>
 </div>

--- a/spec/helpers/profiles_helper_spec.rb
+++ b/spec/helpers/profiles_helper_spec.rb
@@ -2,16 +2,14 @@
 
 require "rails_helper"
 
-# Specs in this file have access to a helper object that includes
-# the ProfilesHelper. For example:
-#
-# describe ProfilesHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe ProfilesHelper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#profile_picture" do
+    subject { helper.profile_picture(email) }
+
+    let(:email) { " TEST@example.com " }
+
+    it "chomps, lowercases, and hashes the email" do
+      is_expected.to eq "https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?s=80&d=retro&r=pg"
+    end
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue
closes #55 

Utilize Gravatar for profile image. This avoids our app being responsible for images that users have uploaded, and saves on costs, because we don't have to have an S3 or GCP bucket. :)

## Checklist
- [x] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?

## User-Facing Changes

Label | Screenshot
---|---
New Profile | ![New Profile - lots of space and a profile picture](https://github.com/ChaelCodes/ConfBuddies/assets/8124558/1088ba42-a75b-4d2f-a76b-9445fbf59628)
Old Profile | ![old profile - no image](https://github.com/ChaelCodes/ConfBuddies/assets/8124558/66bab658-2251-490e-a892-cb35a59a9709)
New Profile Mobile | ![new profile - spacious](https://github.com/ChaelCodes/ConfBuddies/assets/8124558/3b2f9c8a-ebef-49fc-bc0f-20118a372c79)
Old Profile Mobile | ![old profile - squished against walls](https://github.com/ChaelCodes/ConfBuddies/assets/8124558/21e106b7-8270-43da-a0fc-e30496252011)


